### PR TITLE
Validating variant processing scripts against ClinGen variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,15 +162,8 @@ cython_debug/
 #.idea/
 
 # seqrepo download is too large to be included in the repository
-<<<<<<< HEAD
-genome_databases/2024-05-23/
-genome_databases/2024-12-20/
-# clingen and clinvar datasets have similar issue
-genome_databases/erepo.tabbed.txt
-genome_databases/erepo.tabbed.small.txt
-genome_databases/variant_summary.txt
-=======
 data/2024-05-23/
+data/2024-12-20/
 # clingen and clinvar datasets have similar issue
 data/erepo.tabbed.txt
 data/variant_summary.txt
@@ -180,4 +173,3 @@ checkpoints/
 
 # generally we don't need to save jupyter notebooks in the repository
 *.ipynb
->>>>>>> main

--- a/hsg/pipelines/variantmap.py
+++ b/hsg/pipelines/variantmap.py
@@ -130,7 +130,7 @@ class DNAVariantProcessor():
 
         del_len = int(variant_end) - (int(variant_start)-1)
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
-        var_seq = ref_seq[:offset]+ref_seq[offset+del_len:]
+        var_seq = ref_seq[:offset]+ref_seq[offset+del_len:] # start idx is inclusive, end idx is exclusive
         return(var_seq)
         
 
@@ -142,7 +142,7 @@ class DNAVariantProcessor():
 
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
         alt_nuc = str(hgvs_ref.posedit.edit.alt)
-        var_seq = ref_seq[:offset]+alt_nuc+ref_seq[offset:]
+        var_seq = ref_seq[:offset]+alt_nuc+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
         return var_seq
     
 
@@ -155,7 +155,7 @@ class DNAVariantProcessor():
         dup_length = int(variant_end) - (int(variant_start)-1)
 
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
-        var_seq = ref_seq[:offset]+ref_seq[offset-dup_length:offset]+ref_seq[offset:]
+        var_seq = ref_seq[:offset]+ref_seq[offset-1-dup_length:offset]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
 
         return var_seq
 

--- a/hsg/pipelines/variantmap.py
+++ b/hsg/pipelines/variantmap.py
@@ -20,15 +20,31 @@ load_dotenv()
 class DNAVariantProcessor():
 
     """
-    Class for processing hgvs variant expressions to obtain raw sequences for reference and variant alleles
+    Class for processing hgvs variant expressions to obtain raw sequences for reference and variant alleles.
+    Aggregates biocommons utilities for parsing hgvs nomenclature and retrieving sequences as strings.
+
+    Methods:
+    - clean_hgvs
+    - parse_variant
+    - genomic_sequence_projection
+    - determine_variant_type
+    - process_del
+    - process_snp
+    - process_dup
+    - retrieve_refseq
+    - retrieve_variantseq
+    - trim_string_odd
     """
 
     def __init__(self, assembly:str = "GRCh38.p14", seqrepo_path:str = os.environ["SEQREPO_PATH"]) -> None:
+        """
+        Start me up with a parser, assembly mapper, and sequence repository.
+        """
         # hgvs tools
         self.parser:Parser = Parser()
         self.assembly_mapper:AssemblyMapper = AssemblyMapper(
             connect(), 
-            normalize=False,
+            normalize=False, # found this can cause problems with some clingen variants
             assembly_name=assembly, 
             alt_aln_method='blat',
             replace_reference=True
@@ -39,7 +55,8 @@ class DNAVariantProcessor():
     def clean_hgvs(self, raw_hgvs_expression:str) -> str:
 
         """
-        Processes hgvs expressions with gene name and predicted protein change annotations and removes them for machine readability.
+        Processes hgvs expressions with gene name and predicted protein change annotations in parenthesis and removes 
+        them for machine readability.
         """
 
         # remove gene annotations
@@ -58,6 +75,23 @@ class DNAVariantProcessor():
         If hgvs cannot parse the expression, it will return an exception.
 
         This behavior can be changed by setting return_exceptions to False, which, will cause invalid or uncertain expressions to return None -- useful during ML training.
+        
+
+        Args:
+
+        - hgvs_expression: str
+
+            HGVS expression to be processed.
+
+        - return_exceptions: bool
+
+            If True, exceptions will be returned. If False, None will be returned for invalid or uncertain expressions.
+
+            
+        Returns:
+
+        - SequenceVariant object or None
+
         """
 
         try:
@@ -79,8 +113,8 @@ class DNAVariantProcessor():
         Returns a SequenceVariant object.
         1. Determine the coordinate type of the variant (g, c, n, t).
         2. Use the AssemblyMapper to project the variant to genomic coordinates.
-        3. Normalize the variant using the AssemblyMapper.
-        4. Return the projected and normalized variant.
+        3. If the variant appears to be referenced with a different assembly, AssemblyMapper attempts to convert the reference.
+        4. Return the projected variant.
         5. If the coordinate type is not supported, raise a ValueError.
         """
 
@@ -110,6 +144,19 @@ class DNAVariantProcessor():
 
         """
         Determines the type of variant based on the HGVS expression.
+
+        
+        Args:
+
+        - hgvs_expression: str
+
+            HGVS expression to be processed.
+
+            
+        Returns:
+
+        One of: ["del", "SNP", "dup", "unknown"]
+
         """
 
         if "del" in hgvs_expression:
@@ -126,6 +173,29 @@ class DNAVariantProcessor():
 
         """
         Processes a deletion by deleting the specified sequence region.
+
+        
+        Args:
+
+        - hgvs_ref: SequenceVariant
+
+            SequenceVariant object representing the target variant.
+
+        - variant_start: int
+
+            Start position of the deletion ***Note that this should be a zero-indexed genomic coordinate shifted by [-1].
+
+        - variant_end: int
+
+            End position of the deletion ***Note that this should be a zero-indexed genomic coordinate shifted by [-1].
+
+
+        Returns:
+
+        - var_seq: str
+
+            Sequence with the deletion applied.
+
         """
 
         del_len = int(variant_end) - (int(variant_start)-1)
@@ -148,6 +218,29 @@ class DNAVariantProcessor():
 
         """
         Processes a SNP by replacing the affected base.
+
+        
+        Args:
+
+        - hgvs_ref: SequenceVariant
+
+            SequenceVariant object representing the target variant.
+
+        - variant_start: int
+
+            Start position of the SNP ***Note that this should be a zero-indexed genomic coordinate shifted by [-1].
+
+        - variant_end: int
+
+            End position of the SNP ***Note that this should be a zero-indexed genomic coordinate shifted by [-1].
+
+            
+        Returns:
+
+        - var_seq: str
+
+            Sequence with the SNP applied.
+
         """
 
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
@@ -155,15 +248,33 @@ class DNAVariantProcessor():
         var_seq = ref_seq[:offset]+alt_nuc+ref_seq[offset+1:] # start idx is inclusive, end idx is exclusive
         return var_seq
 
-#        ref_seq = self.retrieve_refseq(hgvs_ref)
-#        alt_nuc = str(hgvs_ref.posedit.edit.alt)
-#        var_seq = ref_seq[:2998]+alt_nuc+ref_seq[2999:]
-#        return var_seq
-
     def process_dup(self, hgvs_ref: SequenceVariant, variant_start: int, variant_end: int) -> str:
 
         """
         Processes a duplication by duplicating the specified sequence region.
+
+        
+        Args:
+
+        - hgvs_ref: SequenceVariant
+
+            SequenceVariant object representing the target variant.
+
+        - variant_start: int
+
+            Start position of the duplication ***Note that this should be a zero-indexed genomic coordinate shifted by [-1].
+
+        - variant_end: int
+
+            End position of the duplication ***Note that this should be a zero-indexed genomic coordinate shifted by [-1].
+
+            
+        Returns:
+
+        - var_seq: str
+
+            Sequence with the duplication applied.
+
         """
 
         dup_length = int(variant_end) - (int(variant_start)-1)
@@ -174,25 +285,37 @@ class DNAVariantProcessor():
 
         return var_seq
 
-#        if int(variant_start) == int(variant_end):
-#            ref_seq = str(self.seq_repo[f"refseq:{hgvs_ref.ac}"])[int(variant_start)-2998 : int(variant_end)+2998]
-#            var_seq = ref_seq[:2998]+ref_seq[2997]+ref_seq[2998:]
-#            return ref_seq
-#        elif int(variant_start) != int(variant_end):
-#            dup_len = int(variant_end) - (int(variant_start)-1)
-#            half_dup_len = dup_len/2
-#            ref_seq = str(self.seq_repo[f"refseq:{hgvs_ref.ac}"])[int(variant_start-(2999+half_dup_len)) : int(variant_end+(2999-half_dup_len))]
-#            mid_ref = int(len(ref_seq)/2)
-#            dup_seq = ref_seq[mid_ref:mid_ref+dup_len]
-#            var_seq = ref_seq[:mid_ref+dup_len]+dup_seq+ref_seq[mid_ref+dup_len:]
-#            trimed_var_seq = self.trim_string_odd(var_seq, 5997)
-#            return trimed_var_seq
-
 
     def retrieve_refseq(self, hgvs_ref:SequenceVariant, return_offset:bool = False) -> str:
 
         """
-        Retrieve reference sequence from seqrepo.
+        Retrieve reference sequence from seqrepo for a given variant as a string. 
+
+        
+        Args:
+
+        - hgvs_ref: SequenceVariant
+
+            SequenceVariant object representing the target variant.
+
+        - return_offset: bool
+
+            If True, the offset for the context window will be returned along with the sequence. This is also the index of the 
+            variant start position relative to the context window. For example, if the variant is at position 3000 in the 
+            context window, the offset will be 3000. 
+            
+            However, if the variant occurs near the end of an accession sequence, it may be shifted to avoid "index 
+            out of bounds" errors. For example, a variant at genomic coordinate 1755 has only 1754 bases to its left, thus,
+            you cannot have 3000 bases to the left of the variant. In this case, the offset will be 1755, indicating that the 
+            variant start position at string index position 1755, as opposed to referencing a genomic coordinate. 
+
+            
+        Returns:
+
+        The reference sequence as a string [~6000 bases long (tokenizer context window limit)]. 
+        
+        If return_offset is True, the offset will be returned as well.
+
         """
 
         full = str(self.seq_repo[hgvs_ref.ac])
@@ -218,16 +341,21 @@ class DNAVariantProcessor():
         else:
             return seq_ref
 
-#        variant_start: int = hgvs_ref.posedit.pos.start.base
-#        variant_end: int = hgvs_ref.posedit.pos.end.base
-#        seq_ref = str(self.seq_repo[f"refseq:{hgvs_ref.ac}"])[int(variant_start)-2999 : int(variant_end)+2998]
-    
-#        return seq_ref
 
     def retrieve_variantseq(self, hgvs_ref: SequenceVariant) -> str:
 
         """
         Modifies obtained refseq sequence to obtain the variant sequence
+
+        Args:
+        - hgvs_ref: SequenceVariant
+
+            SequenceVariant object representing the target variant.
+
+        Returns:
+        - var_seq: str
+
+            Sequence mutated per HGVS variant expression.
         """
 
         var_type = self.determine_variant_type(str(hgvs_ref))
@@ -252,6 +380,20 @@ class DNAVariantProcessor():
         Trims a sequence to a target length from both ends. 
 
         If the sequence length is odd, the extra base will be removed from the end of the sequence.
+
+        Args:
+        - s: str
+
+            Sequence to be trimmed.
+        
+        - target_length: int
+
+            Target length for the sequence.
+        
+            
+        Returns:
+
+        The trimmed sequence as a string.
         """
         
         current_length = len(s)

--- a/hsg/pipelines/variantmap.py
+++ b/hsg/pipelines/variantmap.py
@@ -130,7 +130,7 @@ class DNAVariantProcessor():
 
         del_len = int(variant_end) - (int(variant_start)-1)
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
-        var_seq = ref_seq[:offset-1]+ref_seq[(offset+del_len)-1:] # start idx is inclusive, end idx is exclusive
+        var_seq = ref_seq[:offset]+ref_seq[(offset+del_len):] # start idx is inclusive, end idx is exclusive
         return(var_seq)
         
 
@@ -156,7 +156,7 @@ class DNAVariantProcessor():
 
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
         
-        var_seq = ref_seq[:offset]+ref_seq[offset-dup_length:offset-1]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
+        var_seq = ref_seq[:offset]+ref_seq[offset:offset+dup_length]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
 
         return var_seq
 

--- a/hsg/pipelines/variantmap.py
+++ b/hsg/pipelines/variantmap.py
@@ -155,7 +155,8 @@ class DNAVariantProcessor():
         dup_length = int(variant_end) - (int(variant_start)-1)
 
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
-        var_seq = ref_seq[:offset]+ref_seq[offset-1-dup_length:offset]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
+        
+        var_seq = ref_seq[:offset]+ref_seq[offset-dup_length:offset+1]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
 
         return var_seq
 

--- a/hsg/pipelines/variantmap.py
+++ b/hsg/pipelines/variantmap.py
@@ -130,7 +130,7 @@ class DNAVariantProcessor():
 
         del_len = int(variant_end) - (int(variant_start)-1)
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
-        var_seq = ref_seq[:offset]+ref_seq[offset+del_len:] # start idx is inclusive, end idx is exclusive
+        var_seq = ref_seq[:offset-1]+ref_seq[(offset+del_len)-1:] # start idx is inclusive, end idx is exclusive
         return(var_seq)
         
 
@@ -156,7 +156,7 @@ class DNAVariantProcessor():
 
         ref_seq, offset = self.retrieve_refseq(hgvs_ref, return_offset=True)
         
-        var_seq = ref_seq[:offset]+ref_seq[offset-dup_length:offset+1]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
+        var_seq = ref_seq[:offset]+ref_seq[offset-dup_length:offset-1]+ref_seq[offset:] # start idx is inclusive, end idx is exclusive
 
         return var_seq
 

--- a/hsg/pipelines/variantmap.py
+++ b/hsg/pipelines/variantmap.py
@@ -191,6 +191,7 @@ class DNAVariantProcessor():
         """
         Modifies obtained refseq sequence to obtain the variant sequence
         """
+
         var_type = self.determine_variant_type(str(hgvs_ref))
 
         variant_start: int = hgvs_ref.posedit.pos.start.base
@@ -207,6 +208,13 @@ class DNAVariantProcessor():
         
 
     def trim_string_odd(self, s: str, target_length: int) -> str:
+
+        """
+        Trims a sequence to a target length from both ends. 
+
+        If the sequence length is odd, the extra base will be removed from the end of the sequence.
+        """
+        
         current_length = len(s)
     
         if target_length >= current_length:

--- a/hsg/sae/protocol/checkpoint.py
+++ b/hsg/sae/protocol/checkpoint.py
@@ -40,7 +40,7 @@ class History():
         index = self.history["epoch"].index(self.best_epoch)
         metrics = {
             "train": self.history["train"][index],
-            "val": self.history["train"][index],
+            "val": self.history["val"][index],
             "epoch": self.history["epoch"][index]
         }
 

--- a/hsg/sae/train.py
+++ b/hsg/sae/train.py
@@ -192,13 +192,10 @@ def train_all_layers(
     if silent:
         import warnings
         warnings.filterwarnings("ignore")
-        logging.disable(logging.INFO)
-        logging.disable(logging.WARNING)
-        logging.disable(logging.DEBUG)
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.INFO)
         logging.getLogger("main").addHandler(logging.StreamHandler(sys.stdout))
     else:
-        logging.basicConfig(level=logging.INFO)
+        logging.basicConfig(level=logging.WARNING)
         logging.getLogger("main").addHandler(logging.StreamHandler(sys.stdout))
 
     # gather objects

--- a/hsg/sae/train.py
+++ b/hsg/sae/train.py
@@ -121,8 +121,11 @@ def train_sae(
         avg_val_loss = sum(val_loss) / len(val_loss)
         avg_val_acc = sum(val_acc) / len(val_acc)
 
+        # wait until L1 penalty annealing to attempt early stopping
+        if epoch >= l1_annealing_steps:
+            tracker.update(SAE, train_acc, avg_val_acc, epoch)
+        
         # checkpoint logic
-        tracker.update(SAE, train_acc, avg_val_acc, epoch)
         if tracker.early_stop:
             logging.info(f"Early stopping at epoch {epoch}.")
 #            SAE = tracker.reload_checkpoint(SAE)

--- a/hsg/tests/test_env_vars.py
+++ b/hsg/tests/test_env_vars.py
@@ -8,6 +8,9 @@ load_dotenv()
 class Test_EnvVarsSet(unittest.TestCase):
 
     def test_env_vars_set(self):
+        """
+        Make sure that all the necessary environment variables are set using a .env file
+        """
 
         self.assertIsNotNone(os.getenv('CLIN_GEN_CSV'))
         self.assertIsNotNone(os.getenv('CLIN_VAR_CSV'))

--- a/hsg/tests/test_pipelines.py
+++ b/hsg/tests/test_pipelines.py
@@ -22,6 +22,9 @@ class TestDNAVariant(unittest.TestCase):
 
 
     def test_parse_hgvs(self):
+        """
+        Testing the parsing of HGVS expressions using the clingen variant names.
+        """
 
         print("Testing HGVS Parsing")
         print("====================")
@@ -48,6 +51,25 @@ class TestDNAVariant(unittest.TestCase):
 
     
     def test_sequence_retrieval(self):
+        """
+        Testing the retrieval of reference and variant sequences from a given variant. Uses the clingen dataset's
+        HGVS Expressions column to test.
+
+        Steps:
+
+        (1) Pulls a random sample of 1000 variants from the clingen dataset and tests the retrieval of reference and variant
+        sequences, preferring to use genomic coordinates where possible.
+
+        (2) Attempts to parse and project the variant using the hgvs package.
+
+        (3) Attempts to retrieve the reference sequence from biocommons.seqrepo
+
+        (4) Attempts to mutate the reference sequence to the variant sequence per its HGVS expression.
+
+        (5) Run a series of tests to ensure that edits are being made correctly using difflib.
+
+        (6) Report on the number of failures and the types of failures encountered.
+        """
 
         print("Testing Reference Sequence Retrieval & Variant Sequence Mapping")
         print("===================================")

--- a/hsg/tests/test_pipelines.py
+++ b/hsg/tests/test_pipelines.py
@@ -114,7 +114,11 @@ class TestDNAVariant(unittest.TestCase):
             self.assertIsInstance(refseq, str)
 
             # check that the variant sequence is not the same as the reference sequence
-            self.assertNotEqual(varseq, refseq)
+            # Also, return something a bit more informative than a generic assertion error
+            try:
+                self.assertNotEqual(varseq, refseq)
+            except Exception as e:
+                return e, var
 
             ###############################################
             # check mutations for correctness using difflib

--- a/hsg/tests/test_pipelines.py
+++ b/hsg/tests/test_pipelines.py
@@ -118,7 +118,8 @@ class TestDNAVariant(unittest.TestCase):
             try:
                 self.assertNotEqual(varseq, refseq)
             except Exception as e:
-                return e, var
+                print(var)
+                raise e 
 
             ###############################################
             # check mutations for correctness using difflib
@@ -146,7 +147,7 @@ class TestDNAVariant(unittest.TestCase):
                     self.assertEqual(j2a, j1b)
 
                     # check deletion sizes
-                    del_size = var_obj.posedit.pos.end.base - var_obj.posedit.pos.start.base                       
+                    del_size = var_obj.posedit.pos.end.base - var_obj.posedit.pos.start.base +1                    
                     self.assertEqual(i2b, j2b + del_size)
                     
                     # match trailing refseq

--- a/hsg/tests/test_pipelines.py
+++ b/hsg/tests/test_pipelines.py
@@ -5,6 +5,7 @@ import os
 from hgvs.sequencevariant import SequenceVariant
 import pandas as pd
 from tqdm import tqdm
+import difflib
 
 from hsg.pipelines.variantmap import DNAVariantProcessor
 
@@ -41,8 +42,8 @@ class TestDNAVariant(unittest.TestCase):
             self.assertIsInstance(var_obj, SequenceVariant)
 
         print(f"Unable to process {invalid_expressions} out of {len(self.clin_gen)}")
-        print("""This may be due to invalid or uncertain HGVS expressions. See https://hgvs-nomenclature.org/stable/recommendations/summary/ for proper syntax. \n
-              Note that the hgvs package does not currently support all HGVS expression types.""")
+        print("This may be due to invalid or uncertain HGVS expressions. See https://hgvs-nomenclature.org/stable/recommendations/summary/ for proper syntax.")
+        print("Note that the hgvs package does not currently support all HGVS expression types.")
         print("====================")
 
     
@@ -53,8 +54,22 @@ class TestDNAVariant(unittest.TestCase):
 
         # current mapping of all 9025 clin gen variants takes hours
         # so we will test a subset of 1000
-        rand_1000 = self.clin_gen["#Variation"].sample(n=1000)
+        sample = self.clin_gen["HGVS Expressions"].sample(n=1000)
 
+        # pick out g. nomenclature, if we have been graced with it
+        rand_1000 = []
+        for exp_set in sample:
+            exp_set = exp_set.split(",")
+            for i, exp in enumerate(exp_set):
+                if ":g." in exp:
+                    rand_1000.append(exp.strip())
+                    break
+                if i == len(exp_set) - 1:
+                    rand_1000.append(exp.strip())
+                else:
+                    continue
+
+        # count failures
         bad_parse = 0
         bad_retrieval = 0
         bad_projection = 0 
@@ -93,15 +108,59 @@ class TestDNAVariant(unittest.TestCase):
                 bad_mapping += 1
                 continue
 
+            # type checking
+            self.assertIsInstance(varseq, str)
+            self.assertIsInstance(refseq, str)
+
+            # check that the variant sequence is not the same as the reference sequence
+            self.assertNotEqual(varseq, refseq)
+
+            ###############################################
+            # check mutations for correctness using difflib
+            ###############################################
+
+            diff = [i for i in difflib.ndiff(refseq, varseq) if i[0] != ' ']
+
+            # test conditions for deletions
+            if var_obj.posedit.edit.type == "del":
+                self.assertTrue("-" in ''.join(diff))
+                self.assertFalse("+" in ''.join(diff))
+            
+            # test conditions for substitutions / SNPs
+            if var_obj.posedit.edit.type == "sub":
+                self.assertTrue("+" in ''.join(diff))
+                self.assertTrue("-" in ''.join(diff))
+
+                additions = len([i for i in diff if i[0] == "+"])
+                deletions = len([i for i in diff if i[0] == "-"])
+
+                self.assertEqual(additions, deletions)
+
+            # test conditions for insertions
+            if var_obj.posedit.edit.type == "ins":
+                self.assertTrue("+" in ''.join(diff))
+                self.assertFalse("-" in ''.join(diff))
+
+            # test conditions for duplications
+            if var_obj.posedit.edit.type == "dup":
+                self.assertTrue("+" in ''.join(diff))
+                self.assertFalse("-" in ''.join(diff))
+
+            # test conditions for delins
+            if var_obj.posedit.edit.type == "delins":
+                self.assertTrue("+" in ''.join(diff))
+                self.assertTrue("-" in ''.join(diff))
+            
+            # other / complex variants not yet supported, should have thrown error earlier
             else:
-                self.assertIsInstance(varseq, str)
-                self.assertIsInstance(refseq, str)
+                continue
+            
 
         print(f"Unable to parse {bad_parse} out of {len(rand_1000)}")
-        print(f"Unable to project {bad_projection} out of {len(rand_1000)}")
-        print(f"Unable to retrieve {bad_retrieval} out of {len(rand_1000)}")
-        print(f"Unable to map {bad_mapping} out of {len(rand_1000)}")
-        print(f"Total failures: {bad_parse + bad_projection + bad_retrieval + bad_mapping}")
+        print(f"Unable to project {bad_projection} out of {len(rand_1000) - bad_parse}")
+        print(f"Unable to retrieve {bad_retrieval} out of {len(rand_1000) - bad_parse - bad_projection}")
+        print(f"Unable to map {bad_mapping} out of {len(rand_1000) - bad_parse - bad_projection - bad_retrieval}")
+        print(f"Total failures: {bad_parse + bad_projection + bad_retrieval + bad_mapping} / {len(rand_1000)}")
         print("===================================")
 
 

--- a/hsg/tests/test_sae_objects.py
+++ b/hsg/tests/test_sae_objects.py
@@ -20,6 +20,9 @@ load_dotenv()
 class Test_NT_2_5B_MultiSpecies(unittest.TestCase):
 
     def test_tokenizer_load(self):
+        """
+        Test that the tokenizer loads correctly
+        """
 
         print("Testing Tokenizer Load")
         print("======================")
@@ -30,6 +33,9 @@ class Test_NT_2_5B_MultiSpecies(unittest.TestCase):
     
 
     def test_model_load(self):
+        """
+        Test that we can load a nucleotide transformer foundation model
+        """
 
         print("Testing Model Load")
         print("==================")
@@ -40,6 +46,9 @@ class Test_NT_2_5B_MultiSpecies(unittest.TestCase):
 
 
     def test_dummy_encode(self):
+        """
+        Test the forward method of the model combined with the tokenizer for basic functionality.
+        """
 
         print("Testing Dummy Encoding")
         print("======================")
@@ -84,6 +93,9 @@ class Test_NT_2_5B_MultiSpecies(unittest.TestCase):
 
 
     def test_nnsight_interleave(self):
+        """
+        Test that nnsight constructs an intervention graph and allows us to modify hidden layer activations.
+        """
 
         print("Testing NNsight Interleave")
         print("==========================")
@@ -112,6 +124,9 @@ class Test_NT_2_5B_MultiSpecies(unittest.TestCase):
 class Test_Dictionary_Objects(unittest.TestCase):
 
     def test_autoencoder_instance(self):
+        """
+        Test initialization of our AutoEncoder class
+        """
 
         print("Testing AutoEncoder Initialization")
         print("=================================")


### PR DESCRIPTION
- Wrote unit tests for the DNAVariantProcessor to establish that edits to refseqs are being made as described and that variant sequences are reliably mutated according to their HGVS descriptor in the correct location. 
- Introduced some changes to the training script to delay early stopping protocols until after L1 annealing
- Refactored the DNAVariantProcessor to dynamically assign an offset value for the context window. This prevents variants that occur close to the ends of refseq sequences from throwing an out of index error, and makes mapping more consistent generally.